### PR TITLE
Add CV page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,9 @@ github_username:  jekyll
 theme: minima
 plugins:
   - jekyll-feed
+header_pages:
+  - about.markdown
+  - cv.markdown
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/cv.markdown
+++ b/cv.markdown
@@ -1,0 +1,22 @@
+---
+layout: page
+title: CV
+permalink: /cv/
+---
+
+## Winit Sansare
+
+### Education
+- **B.Tech. in Computer Science**, Example University (2016)
+
+### Experience
+- **Software Developer**, ExampleCorp (2020&ndash;Present)
+- **Intern**, SampleCompany (2019)
+
+### Skills
+- Python, JavaScript, Ruby
+- Web Development, DevOps
+
+### Contact
+- Email: winit@example.com
+- GitHub: [github.com/winitsansare](https://github.com/winitsansare)


### PR DESCRIPTION
## Summary
- add a CV page with example details
- list the CV page in the navigation header

## Testing
- `bundle exec jekyll build` *(fails: bundler cannot find jekyll executable)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9c846f08326985bf825822ab6d1