### PR TITLE
Fix Gemfile plugin version mismatch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "minima", "~> 2.5"
 # gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-feed", "~> 0.15"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# hellowinit.github.io
+# winitsansare.github.io
 A blogging platform for my work, hobbies and much more. :)


### PR DESCRIPTION
## Summary
- update README repo name
- fix jekyll-feed version in Gemfile

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff842fbf88326a45db62b6c30dd37