### PR TITLE
Fix hidden posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,9 @@ url: "https://winitsansare.github.io" # the base hostname & protocol for your si
 twitter_username: vinitsansare
 github_username:  WinitSansare
 
+# Display posts scheduled for future dates
+future: true
+
 # Build settings
 theme: minima
 plugins:


### PR DESCRIPTION
## Summary
- show posts dated in the future by enabling `future: true`

## Testing
- `ruby -v`

------
https://chatgpt.com/codex/tasks/task_e_68421cfd5b1883269da564aa88fb7c5c