### PR TITLE
Add categories page and categorize posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ plugins:
 header_pages:
   - about.markdown
   - cv.markdown
+  - categories.markdown
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/_posts/2020-08-25-welcome-to-jekyll.markdown
+++ b/_posts/2020-08-25-welcome-to-jekyll.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Welcome to Jekyll!"
 date:   2020-08-25 08:45:31 +0530
-categories: jekyll update
+categories: programming
 ---
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
 

--- a/_posts/2025-06-05-introduction-to-kubernetes.markdown
+++ b/_posts/2025-06-05-introduction-to-kubernetes.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Introduction to Kubernetes"
 date: 2025-06-05 22:00:00 +0000
-categories: kubernetes
+categories: devops
 ---
 Kubernetes, often abbreviated as K8s, is an open source system for automating the deployment, scaling, and management of containerized applications. It was originally created by Google and has since become the de facto standard for container orchestration.
 

--- a/_posts/2025-06-06-getting-started-with-docker.markdown
+++ b/_posts/2025-06-06-getting-started-with-docker.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Getting Started with Docker"
 date: 2025-06-06 22:00:00 +0000
-categories: docker
+categories: devops
 ---
 Docker is a platform that simplifies building, running, and shipping applications using containers. Containers package an application with all its dependencies, ensuring consistent behavior across environments.
 

--- a/categories.markdown
+++ b/categories.markdown
@@ -1,0 +1,19 @@
+---
+layout: page
+title: Categories
+---
+
+<ul>
+  {% for category in site.categories %}
+    <li><a href="#{{ category[0] | slugify }}">{{ category[0] | capitalize }}</a></li>
+  {% endfor %}
+</ul>
+
+{% for category in site.categories %}
+  <h2 id="{{ category[0] | slugify }}">{{ category[0] | capitalize }}</h2>
+  <ul>
+    {% for post in category[1] %}
+      <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+    {% endfor %}
+  </ul>
+{% endfor %}


### PR DESCRIPTION
## Summary
- add `categories.markdown` page to list post categories
- show categories navigation link
- categorize existing posts under `programming` and `devops`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68421df95e308326aa1e2c216d6dfce3